### PR TITLE
Adiciona .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*.code-workspace


### PR DESCRIPTION
Como uso o Visual Studio Code e gosto de ter um _workspace_ definido para cada projecto, preciso de dizer ao `git` para ignorar os ficheiros onde essas definições ficam guardadas (`*.code-workspace`).